### PR TITLE
Fix compilation on Fedora 31

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,8 @@ if test "x$ac_cv_prog_cc_c99" = "xno"; then
 fi
 AC_HEADER_STDC
 
+AC_SEARCH_LIBS([round], [m])
+
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
 PKG_CHECK_MODULES([GTK3], [gtk+-3.0])
 PKG_CHECK_MODULES([LIBPULSE], [libpulse])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,7 @@ pa_applet_SOURCES = \
     volume_scale.h
 
 pa_applet_CPPFLAGS = \
-    -std=c99 -D_GNU_SOURCE -Wall -Werror \
+    -std=c99 -D_GNU_SOURCE -Wall -Werror -Wno-error=deprecated-declarations \
     $(GLIB_CFLAGS) \
     $(GTK3_CFLAGS) \
     $(LIBPULSE_CFLAGS) \


### PR DESCRIPTION
This contains a cherry-pick of https://github.com/fernandotcl/pa-applet/commit/3b4f8b3f0d0b12dcba2a78d8f2a0b06f1d377bd2 (from https://github.com/fernandotcl/pa-applet/pull/23) to make things compile with newer GTK/GDK versions, and a fix to link libm into the binary if needed. The latter avoids this error:

~~~~
gcc  -g -O2   -o pa-applet pa_applet-audio_status.o pa_applet-key_grabber.o pa_applet-main.o pa_applet-notifications.o pa_applet-popup_menu.o pa_applet-pulse_glue.o pa_applet-tray_icon.o pa_applet-volume_scale.o -lglib-2.0  -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0  -lpulse  -lpulse-mainloop-glib -lpulse -lglib-2.0  -lnotify -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0  -lX11  
/usr/bin/ld: pa_applet-notifications.o: undefined reference to symbol 'round@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib64/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
~~~~